### PR TITLE
Update fxmanifest to use oxmysql instead of mysql-async

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -25,7 +25,7 @@ shared_scripts {
 }
 
 server_scripts {
-    '@mysql-async/lib/MySQL.lua',
+    '@oxmysql/lib/MySQL.lua',
     'settings/DreamCoreExt.lua',
     'bridge/**/server.lua',
     'server/main.lua'


### PR DESCRIPTION
[oxmysql](https://github.com/overextended/oxmysql) is a modern replacement for MySQL-Async and ghmattimysql 